### PR TITLE
Added error handling while watching on desired value for led-raspberryPi

### DIFF
--- a/led-raspberrypi/light_mapper.go
+++ b/led-raspberrypi/light_mapper.go
@@ -244,7 +244,7 @@ func equateTwinValue(updateMessage DeviceTwinUpdate) {
 	go subscribe()
 	getTwin(updateMessage)
 	wg.Wait()
-	if deviceTwinResult.Twin[powerStatus].Actual == nil || *deviceTwinResult.Twin[powerStatus].Expected.Value != *deviceTwinResult.Twin[powerStatus].Actual.Value {
+	if deviceTwinResult.Twin[powerStatus].Expected != nil && ((deviceTwinResult.Twin[powerStatus].Actual == nil) && deviceTwinResult.Twin[powerStatus].Expected != nil || (*deviceTwinResult.Twin[powerStatus].Expected.Value != *deviceTwinResult.Twin[powerStatus].Actual.Value)) {
 		glog.Info("Expected Value : ", *deviceTwinResult.Twin[powerStatus].Expected.Value)
 		if deviceTwinResult.Twin[powerStatus].Actual == nil {
 			glog.Info("Actual Value: ", deviceTwinResult.Twin[powerStatus].Actual)

--- a/led-raspberrypi/sample-crds/led-light-device-instance.yaml
+++ b/led-raspberrypi/sample-crds/led-light-device-instance.yaml
@@ -18,4 +18,8 @@ spec:
 status:
   twins:
     - propertyName: power-status
+      desired:
+        metadata:
+          type: string
+        value: 'OFF'
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**
This PR adds nil pointer error handling while watching on desired value for led raspberryPi, along with addition of desired values in the device crd

**Which issue(s) this PR fixes**
Fixes #22