### PR TITLE
fix new-counter-demo web UI upstream status handling

### DIFF
--- a/new-counter-demo/webUI/handlers/counter.go
+++ b/new-counter-demo/webUI/handlers/counter.go
@@ -12,6 +12,8 @@ const (
 	IP = "127.0.0.1"
 )
 
+var edgeAPIBaseURL = "http://" + IP + ":30077"
+
 func isSuccessStatus(statusCode int) bool {
 	return statusCode >= http.StatusOK && statusCode < http.StatusMultipleChoices
 }
@@ -31,7 +33,7 @@ type EdgeAPIResponse struct {
 }
 
 func GetCounter(c *gin.Context) {
-	url := "http://" + IP + ":30077/api/v1/device/default/counter-instance/count"
+	url := edgeAPIBaseURL + "/api/v1/device/default/counter-instance/count"
 	resp, err := http.Get(url)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
@@ -54,7 +56,7 @@ func GetCounter(c *gin.Context) {
 }
 
 func GetStatus(c *gin.Context) {
-	url := "http://" + IP + ":30077/api/v1/device/default/counter-instance/status"
+	url := edgeAPIBaseURL + "/api/v1/device/default/counter-instance/status"
 	resp, err := http.Get(url)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get switch status" + err.Error()})
@@ -78,7 +80,7 @@ func GetStatus(c *gin.Context) {
 func SetStatus(c *gin.Context) {
 	Status := c.Query("status")
 
-	url := "http://" + IP + ":30077/api/v1/devicemethod/default/counter-instance/UpdateStatus/status/" + Status
+	url := edgeAPIBaseURL + "/api/v1/devicemethod/default/counter-instance/UpdateStatus/status/" + Status
 	resp, err := http.Get(url)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to set switch status" + err.Error()})
@@ -94,7 +96,7 @@ func SetStatus(c *gin.Context) {
 }
 
 func ResetCount(c *gin.Context) {
-	url := "http://" + IP + ":30077/api/v1/devicemethod/default/counter-instance/SetCount/count/0"
+	url := edgeAPIBaseURL + "/api/v1/devicemethod/default/counter-instance/SetCount/count/0"
 	resp, err := http.Get(url)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to reset count" + err.Error()})
@@ -110,7 +112,7 @@ func ResetCount(c *gin.Context) {
 
 func SetCount(c *gin.Context) {
 	Count := c.Query("count")
-	url := "http://" + IP + ":30077/api/v1/devicemethod/default/counter-instance/SetCount/count/" + Count
+	url := edgeAPIBaseURL + "/api/v1/devicemethod/default/counter-instance/SetCount/count/" + Count
 	resp, err := http.Get(url)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to set count" + err.Error()})

--- a/new-counter-demo/webUI/handlers/counter.go
+++ b/new-counter-demo/webUI/handlers/counter.go
@@ -12,17 +12,21 @@ const (
 	IP = "127.0.0.1"
 )
 
+func isSuccessStatus(statusCode int) bool {
+	return statusCode >= http.StatusOK && statusCode < http.StatusMultipleChoices
+}
+
 type EdgeAPIResponse struct {
 	APIVersion string `json:"apiVersion"`
 	StatusCode int    `json:"statusCode"`
 	TimeStamp  string `json:"timeStamp"`
 	Data       struct {
-		DeviceName   string      `json:"DeviceName"`
-		PropertyName string      `json:"PropertyName"`
-		Namespace    string      `json:"Namespace"`
-		Value        string      `json:"Value"` 
-		Type         string      `json:"Type"`
-		TimeStamp    int64       `json:"TimeStamp"`
+		DeviceName   string `json:"DeviceName"`
+		PropertyName string `json:"PropertyName"`
+		Namespace    string `json:"Namespace"`
+		Value        string `json:"Value"`
+		Type         string `json:"Type"`
+		TimeStamp    int64  `json:"TimeStamp"`
 	} `json:"Data"`
 }
 
@@ -34,6 +38,10 @@ func GetCounter(c *gin.Context) {
 		return
 	}
 	defer resp.Body.Close()
+	if !isSuccessStatus(resp.StatusCode) {
+		c.JSON(http.StatusBadGateway, gin.H{"error": "KubeEdge API returned status " + resp.Status})
+		return
+	}
 
 	var edgeResp EdgeAPIResponse
 	if err := json.NewDecoder(resp.Body).Decode(&edgeResp); err != nil {
@@ -49,10 +57,14 @@ func GetStatus(c *gin.Context) {
 	url := "http://" + IP + ":30077/api/v1/device/default/counter-instance/status"
 	resp, err := http.Get(url)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get switch status"+err.Error()})
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get switch status" + err.Error()})
 		return
 	}
 	defer resp.Body.Close()
+	if !isSuccessStatus(resp.StatusCode) {
+		c.JSON(http.StatusBadGateway, gin.H{"error": "KubeEdge API returned status " + resp.Status})
+		return
+	}
 
 	var edgeResp EdgeAPIResponse
 	if err := json.NewDecoder(resp.Body).Decode(&edgeResp); err != nil {
@@ -63,40 +75,51 @@ func GetStatus(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"status": edgeResp.Data.Value})
 }
 
-
 func SetStatus(c *gin.Context) {
-	Status :=c.Query("status")
+	Status := c.Query("status")
 
-	url := "http://" + IP + ":30077/api/v1/devicemethod/default/counter-instance/UpdateStatus/status/"+Status
-	resp,err:=http.Get(url)
+	url := "http://" + IP + ":30077/api/v1/devicemethod/default/counter-instance/UpdateStatus/status/" + Status
+	resp, err := http.Get(url)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to set switch status"+err.Error()})
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to set switch status" + err.Error()})
 		return
 	}
 	defer resp.Body.Close()
+	if !isSuccessStatus(resp.StatusCode) {
+		c.JSON(http.StatusBadGateway, gin.H{"error": "KubeEdge API returned status " + resp.Status})
+		return
+	}
 
 	c.JSON(http.StatusOK, gin.H{"status": Status, "success": true})
 }
 
 func ResetCount(c *gin.Context) {
 	url := "http://" + IP + ":30077/api/v1/devicemethod/default/counter-instance/SetCount/count/0"
-	resp,err:=http.Get(url)
+	resp, err := http.Get(url)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to reset count"+err.Error()})
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to reset count" + err.Error()})
 		return
 	}
 	defer resp.Body.Close()
+	if !isSuccessStatus(resp.StatusCode) {
+		c.JSON(http.StatusBadGateway, gin.H{"error": "KubeEdge API returned status " + resp.Status})
+		return
+	}
 	c.JSON(http.StatusOK, gin.H{"success": true})
 }
 
 func SetCount(c *gin.Context) {
-	Count :=c.Query("count")
-	url := "http://" + IP + ":30077/api/v1/devicemethod/default/counter-instance/SetCount/count/"+Count
-	resp,err:=http.Get(url)
+	Count := c.Query("count")
+	url := "http://" + IP + ":30077/api/v1/devicemethod/default/counter-instance/SetCount/count/" + Count
+	resp, err := http.Get(url)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to set count"+err.Error()})
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to set count" + err.Error()})
 		return
 	}
 	defer resp.Body.Close()
+	if !isSuccessStatus(resp.StatusCode) {
+		c.JSON(http.StatusBadGateway, gin.H{"error": "KubeEdge API returned status " + resp.Status})
+		return
+	}
 	c.JSON(http.StatusOK, gin.H{"count": Count, "success": true})
 }

--- a/new-counter-demo/webUI/handlers/counter_test.go
+++ b/new-counter-demo/webUI/handlers/counter_test.go
@@ -1,6 +1,13 @@
 package handlers
 
-import "testing"
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
 
 func TestIsSuccessStatus(t *testing.T) {
 	for _, test := range []struct {
@@ -15,5 +22,47 @@ func TestIsSuccessStatus(t *testing.T) {
 		if actual := isSuccessStatus(test.statusCode); actual != test.expected {
 			t.Errorf("isSuccessStatus(%d) = %v, want %v", test.statusCode, actual, test.expected)
 		}
+	}
+}
+
+func TestHandlersRejectNonSuccessUpstreamStatus(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "upstream unavailable", http.StatusServiceUnavailable)
+	}))
+	defer upstream.Close()
+
+	previousBaseURL := edgeAPIBaseURL
+	edgeAPIBaseURL = upstream.URL
+	defer func() {
+		edgeAPIBaseURL = previousBaseURL
+	}()
+
+	gin.SetMode(gin.TestMode)
+	tests := []struct {
+		name    string
+		handler gin.HandlerFunc
+	}{
+		{name: "get counter", handler: GetCounter},
+		{name: "get status", handler: GetStatus},
+		{name: "set status", handler: SetStatus},
+		{name: "reset count", handler: ResetCount},
+		{name: "set count", handler: SetCount},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			context, _ := gin.CreateTestContext(recorder)
+			context.Request = httptest.NewRequest(http.MethodGet, "/?status=on&count=1", nil)
+
+			test.handler(context)
+
+			if recorder.Code != http.StatusBadGateway {
+				t.Fatalf("handler returned status %d, want %d", recorder.Code, http.StatusBadGateway)
+			}
+			if !strings.Contains(recorder.Body.String(), "503 Service Unavailable") {
+				t.Fatalf("handler response %q does not expose the upstream status", recorder.Body.String())
+			}
+		})
 	}
 }

--- a/new-counter-demo/webUI/handlers/counter_test.go
+++ b/new-counter-demo/webUI/handlers/counter_test.go
@@ -1,0 +1,19 @@
+package handlers
+
+import "testing"
+
+func TestIsSuccessStatus(t *testing.T) {
+	for _, test := range []struct {
+		statusCode int
+		expected   bool
+	}{
+		{statusCode: 199, expected: false},
+		{statusCode: 200, expected: true},
+		{statusCode: 204, expected: true},
+		{statusCode: 300, expected: false},
+	} {
+		if actual := isSuccessStatus(test.statusCode); actual != test.expected {
+			t.Errorf("isSuccessStatus(%d) = %v, want %v", test.statusCode, actual, test.expected)
+		}
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Makes the new-counter-demo web UI validate KubeEdge API response status codes before returning success. Non-2xx upstream responses now return an upstream error response instead of being reported as successful operations.

The regression coverage checks the shared 2xx boundary and exercises all five handlers against a controllable upstream returning HTTP 503, verifying that each handler returns HTTP 502 and preserves the upstream status in its response.

**Which issue(s) this PR fixes**:

Fixes #173

**Special notes for your reviewer**:

Validation:

```bash
go test ./handlers
```

**Does this PR introduce a user-facing change?**:

```release-note
Bug fix: report failed upstream API responses from the counter web UI.
```
